### PR TITLE
Point prod at the agentdure storage set, and say which environment is which

### DIFF
--- a/charts/agentdure/values-template.yaml.j2
+++ b/charts/agentdure/values-template.yaml.j2
@@ -8,12 +8,16 @@ app:
       AWS_REGION: ap-northeast-2
       BETTER_AUTH_URL: https://agentdure.com
       PUBLIC_BASE_URL: https://agentdure.com
-      # Capability catalog. Same S3 Vectors bucket mcp-memory writes to, its own
-      # index — an index fixes its dimension and metric at creation, so the two
-      # cannot share one. Created out of band: nothing in terraform-env-demo
-      # manages s3vectors resources.
+      # Capability catalog. This is the prod environment, so every name here is
+      # the `agentdure-*` set; the IDC host is alpha and reads the
+      # `agent-studio-*` one. The two share no storage — a project made on one
+      # is invisible on the other (agentdure repo docs/OPERATIONS.md).
+      #
+      # The bucket holds mcp-memory's index too, but a separate one: an index
+      # fixes its dimension and metric at creation, so the two cannot share one.
+      # Both are managed by terraform-env-demo/demo/9-agentdure.
       CATALOG_INDEX: capabilities
-      VECTOR_BUCKET: agent-studio-vector
+      VECTOR_BUCKET: agentdure-vector
       DYNAMODB_TABLE_NAME: agentdure
       # Cohere rather than mcp-memory's Titan, and the reason is measured: a
       # Korean query against an English description scores 0.39 here and 0.065

--- a/charts/mcp-memory/values-template.yaml.j2
+++ b/charts/mcp-memory/values-template.yaml.j2
@@ -8,7 +8,7 @@ app:
   #
   # No AWS credentials either. The ServiceAccount below is bound to
   # pod-role--mcp-memory by an EKS Pod Identity association, defined in
-  # terraform-env-demo/demo/6-role. Pod Identity needs no annotation on the
+  # terraform-env-demo/demo/8-role. Pod Identity needs no annotation on the
   # ServiceAccount — unlike IRSA — so the only requirement here is that the
   # account exists under exactly the name the association names.
   configmap:
@@ -18,10 +18,15 @@ app:
       # S3 Vectors. The index's dimension, distance metric and non-filterable
       # metadata keys are fixed at creation; see the repository's README before
       # pointing this at a different one.
-      VECTOR_BUCKET: agent-studio-vector
+      #
+      # The `agentdure-*` set is prod's. The IDC host is alpha and keeps writing
+      # to `agent-studio-*`, which is where everything remembered before this
+      # split stayed — the cluster's memory starts empty here. Both sets are
+      # managed by terraform-env-demo/demo/9-agentdure.
+      VECTOR_BUCKET: agentdure-vector
       VECTOR_INDEX: memories
       # Ordinary S3: access counters and the recency index.
-      STATE_BUCKET: agent-studio-memory
+      STATE_BUCKET: agentdure-memory
       # Bedrock needs no key — the pod role covers it — and runs in the same
       # region as the vector bucket. EMBEDDING_DIM must equal the index's.
       EMBEDDING_PROVIDER: bedrock


### PR DESCRIPTION
## Summary

IDC 호스트와 이 클러스터는 **한 시스템을 두 번 읽던 관계**였다. 이제 두 환경으로 가른다:

| | 배포 | 스토리지 |
|---|---|---|
| **alpha** | IDC 호스트 (`alpha.agentdure.com`) | `agent-studio` · `agent-studio-static` · `agent-studio-vector` · `agent-studio-memory` |
| **prod** | EKS 클러스터 (`agentdure.com`) | `agentdure` · `agentdure-static` · `agentdure-vector` · `agentdure-memory` |

한쪽에서 만든 프로젝트가 다른 쪽에 보이지 않는다.

## Changes

버킷 이름 자체는 이미 바뀌어 있었고, 여기서 더한 것은 **그 이름을 읽을 수 있게 하는 문장**과
주석이 틀리게 말하던 것 둘이다:

- `terraform-env-demo` 는 이제 s3vectors 리소스를 관리한다 — 이 페이지의 모든 이름을
  `demo/9-agentdure` 가 소유한다 (기존 주석: "Created out of band: nothing in terraform-env-demo
  manages s3vectors resources")
- pod identity association 은 `demo/8-role` 이다 (기존 주석: `demo/6-role`)

`charts/mcp-memory` 의 `agentdure-vector/memories` 인덱스는 이 이동을 위해 방금 만들어졌고
**비어 있다** — 클러스터의 기억은 0 에서 시작한다. 가르기 전에 기억된 것은 `agent-studio-vector`
에 그대로 있고, 그것은 이제 alpha 의 것이다.

## 선행 조건 (완료)

`terraform-env-demo#24` 의 `9a740f4` 가 apply 됐다. 이것이 없으면 이 PR 은 mcp-memory 를 깨뜨린다:

- `agentdure-vector/memories` 인덱스 생성 (Titan 1024 / cosine / non-filterable 4종)
- `pod-role--mcp-memory` 정책을 두 이름 집합 모두 허용하도록 확장 — 없으면 `AccessDenied`

## Breaking Changes

`demo/values-*.yaml` 은 생성물이라 이 PR 에 없다. 머지 후 `build.sh` 가 렌더하고 ArgoCD 가
동기화하면 클러스터에서 두 가지가 비어 시작한다. **둘 다 파생 데이터라 스스로 회복한다:**

- 케이퍼빌리티 카탈로그 — 재색인 틱(시간당)이 채운다. 그 전까지 discovery 는 아무것도 못 찾는다
- mcp-memory 의 기억 — 회복되지 않고, 새로 쌓인다 (위 참조)

DynamoDB 테이블(`agentdure`)과 정적 버킷은 바뀌지 않으므로 프로젝트·채팅·사용량은 그대로다.

## Test Plan

- [x] `python3 gen_values.py -r agentdure` / `-r mcp-memory` 를 로컬에서 돌려 렌더 결과가
      `VECTOR_BUCKET: agentdure-vector`, `STATE_BUCKET: agentdure-memory` 인 것을 확인한 뒤 되돌렸다
      (생성물은 커밋하지 않는다)
- [x] `aws s3vectors list-indexes --vector-bucket-name agentdure-vector` → `capabilities`,
      `knowledge`, `memories`
- [x] `pod-role--mcp-memory` 정책이 두 이름 집합을 모두 허용
- [ ] 머지 후: 파드 재시작, `/api/health` 200, mcp-memory 가 `AccessDenied` 없이 뜨는 것,
      재색인 틱 뒤 카탈로그 검색이 답하는 것

---

## 머지 시점의 사실 (이 PR 이후 상황이 바뀌었다)

이 PR 을 연 뒤 **prod 를 접기로 결정됐다.** 그래서 지금 이것은 "클러스터를 새 버킷으로 옮기는
변경"이 아니라 **차트가 prod 를 어떻게 설정해야 하는지의 기록**이다.

- EKS 의 agentdure·mcp 워크로드와 **ArgoCD Application 이 삭제됐다** — 이 PR 을 머지해도
  동기화될 대상이 없다. 배포 영향 0
- `agentdure` 테이블(1,779건)과 `agentdure-static`(87개)의 내용은 **alpha 의 `agent-studio`
  쪽으로 옮겨졌고** 원본은 비워졌다. 지금 이 차트가 가리키는 스토리지는 비어 있다
- 서비스는 IDC alpha 호스트(`alpha.agentdure.com`)가 혼자 하고 있다

그럼에도 머지하는 이유는 두 가지다. **이름은 prod 를 다시 세울 때도 맞고**, 이 PR 이 고치는 주석
둘은 상황과 무관하게 참이다 — terraform 이 s3vectors 리소스를 관리한다는 것, pod identity
association 이 `demo/8-role` 이라는 것.
