### PR TITLE
Point agent-studio at PostgreSQL and proxied artifacts

### DIFF
--- a/charts/agent-studio/values-alpha.yaml
+++ b/charts/agent-studio/values-alpha.yaml
@@ -36,6 +36,8 @@ app:
       name: GITHUB_TOKEN
     - key: /k8s/common/agent-studio/schedule-scan-token
       name: SCHEDULE_SCAN_TOKEN
+    - key: /k8s/common/agent-studio/database-url
+      name: DATABASE_URL
     enabled: true
   image:
     tag: v0.86.0

--- a/charts/agent-studio/values-template.yaml.j2
+++ b/charts/agent-studio/values-template.yaml.j2
@@ -8,22 +8,20 @@ app:
       AWS_REGION: ap-northeast-2
       BETTER_AUTH_URL: https://studio.opspresso.com
       PUBLIC_BASE_URL: https://studio.opspresso.com
-      DYNAMODB_TABLE_NAME: agent-studio-prod
+      # Storage since agent-studio v0.87: one PostgreSQL (DATABASE_URL, from
+      # the external secret /k8s/common/agent-studio/database-url — an RDS or
+      # an in-cluster Postgres with pgvector; neither exists for prod yet) and
+      # an S3-compatible bucket for artifacts, served through the app
+      # (ARTIFACT_ACCESS_MODE=proxied) so the bucket needs no public policy.
+      # The capability catalog lives in the database; CATALOG_ENABLED turns it
+      # on. This is the prod environment; the IDC host is alpha and the two
+      # share no storage — a project made on one is invisible on the other
+      # (agent-studio repo docs/OPERATIONS.md).
       S3_BUCKET_NAME: agent-studio-prod-static
+      ARTIFACT_ACCESS_MODE: proxied
+      CATALOG_ENABLED: 'true'
       SLACK_LOADING_INDICATOR: ':loading:'
       TRUSTED_PROXY_CIDRS: 10.10.0.0/16
-      # Capability catalog. This is the prod environment, so every name here is
-      # the `agent-studio-prod-*` set; the IDC host is alpha and reads the
-      # `agent-studio-*` one. The two share no storage — a project made on one
-      # is invisible on the other (agent-studio repo docs/OPERATIONS.md).
-      # The prod set is named but not created yet: terraform-env-demo's
-      # demo/9-agent-studio carries it as a commented env, so until that is
-      # applied this deployment has no table to reach.
-      #
-      # The bucket holds mcp-memory's index too, but a separate one: an index
-      # fixes its dimension and metric at creation, so the two cannot share one.
-      CATALOG_INDEX: capabilities
-      VECTOR_BUCKET: agent-studio-prod-vector
       # Cohere rather than mcp-memory's Titan, and the reason is measured: a
       # Korean query against an English description scores 0.39 here and 0.065
       # on Titan, where unrelated pairs score 0.04 — so this registry is

--- a/charts/agent-studio/values.yaml
+++ b/charts/agent-studio/values.yaml
@@ -215,8 +215,8 @@ scan:
 # buy nothing. Ticking twice is safe: keys are derived from the entry, so a
 # second pass writes the same records and computes the same leftovers.
 #
-# 503 means VECTOR_BUCKET is unset, which -f turns into a failed Job. That is
-# deliberate — a deployment carrying EMBEDDING_* but no bucket should be
+# 503 means CATALOG_ENABLED is off, which -f turns into a failed Job. That is
+# deliberate — a deployment carrying EMBEDDING_* but no catalog should be
 # visible rather than quietly doing nothing.
 reindex:
   fullnameOverride: agent-studio-reindex


### PR DESCRIPTION
## Summary
agent-studio v0.87(opspresso/agent-studio#66)는 모든 행을 PostgreSQL 에 두고(`DATABASE_URL`, 외부 시크릿 `/k8s/common/agent-studio/database-url`) 아티팩트를 앱이 직접 서빙한다(`ARTIFACT_ACCESS_MODE=proxied`). 차트 값에서 DynamoDB·S3 Vectors·카탈로그 인덱스 이름을 빼고 `CATALOG_ENABLED` 를 켠다.

## Changes
- `values-template.yaml.j2`: `DYNAMODB_TABLE_NAME`·`VECTOR_BUCKET`·`CATALOG_INDEX` 제거, `ARTIFACT_ACCESS_MODE=proxied`·`CATALOG_ENABLED=true` 추가
- `values-alpha.yaml`: ExternalSecret 에 `DATABASE_URL` 추가
- `values.yaml`: reindex CronJob 의 503 설명

## Breaking Changes
EKS 배포에는 RDS 또는 클러스터 내 Postgres(pgvector)와 그 URL 의 SSM 파라미터가 먼저 있어야 한다 — 지금 클러스터는 휴면 상태라 영향 없음.

## Test Plan
- [x] `python3 gen_values.py -r agent-studio` 렌더 확인은 다음 배포 시 봇이 수행
- [ ] agent-studio#66 머지 후 alpha 릴리즈와 함께 적용

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added database connection configuration for Agent Studio.
  * Enabled database-backed capability catalog support.
  * Added documentation for PostgreSQL and S3-backed storage.
  * Configured artifact access through the proxy.

* **Documentation**
  * Updated reindexing guidance to clarify that HTTP 503 occurs when the capability catalog is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->